### PR TITLE
Updated pom.xml for Mambu 4.3 to build changes in 4.3-bin.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>Mambu-APIs-Java</groupId>
 	<artifactId>Mambu-APIs-Java</artifactId>
 	<name>Mambu Java APIs SDK</name>
-	<version>4.2-bin</version>
+	<version>4.3-bin</version>
 	<url>http://www.mambu.com</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Updated pom.xml to start building 4.3 changes only in the 4.3-bin.jar

Note: other 4.3 pom.xml changes are still outstanding (e.g. using 4.3. model)